### PR TITLE
feat: implement truncate function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./text";

--- a/src/text.test.ts
+++ b/src/text.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { truncate } from "./text";
+
+describe("truncate", () => {
+  it("should truncate a long string with default lengths [6, 6]", () => {
+    const input = "init1wlvk4e083pd3nddlfe5quy56e68atra3gu9xfs";
+    const expected = "init1w...gu9xfs";
+    expect(truncate(input)).toBe(expected);
+  });
+
+  it("should truncate a long string with custom lengths [3, 3]", () => {
+    const input = "init1wlvk4e083pd3nddlfe5quy56e68atra3gu9xfs";
+    const expected = "ini...xfs";
+    expect(truncate(input, [3, 3])).toBe(expected);
+  });
+
+  it("should not truncate strings shorter than or equal to the combined length", () => {
+    const shortString = "short";
+    expect(truncate(shortString)).toBe("short");
+
+    // With default [6, 6], min length is 15 (6 + 3 + 6)
+    const fifteenChars = "123456789012345"; // exactly 15 characters
+    expect(truncate(fifteenChars)).toBe("123456789012345");
+
+    // With [3, 3], min length is 9 (3 + 3 + 3)
+    const nineChars = "123456789"; // exactly 9 characters
+    expect(truncate(nineChars, [3, 3])).toBe("123456789");
+  });
+
+  it("should handle edge cases", () => {
+    expect(truncate("")).toBe("");
+    expect(truncate("a")).toBe("a");
+    expect(truncate("ab", [1, 1])).toBe("ab");
+  });
+});

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,0 +1,16 @@
+export function truncate(
+  str: string,
+  lengths: [number, number] = [6, 6],
+): string {
+  const [prefixLength, suffixLength] = lengths;
+  const minLength = prefixLength + suffixLength + 3; // 3 for "..."
+
+  if (str.length <= minLength) {
+    return str;
+  }
+
+  const prefix = str.slice(0, prefixLength);
+  const suffix = str.slice(-suffixLength);
+
+  return `${prefix}...${suffix}`;
+}


### PR DESCRIPTION
- Add truncate function to shorten long strings with ellipsis
- Keep specified characters from front and back (default: [6, 6])
- Add comprehensive test cases for the truncate function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a function to shorten long text by preserving the start and end, separated by an ellipsis.
* **Tests**
  * Introduced tests to verify the new text-shortening functionality, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->