### PR TITLE
fix: use toFixed() instead of toString() in toBaseUnit for large numbers

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -432,6 +432,12 @@ describe("toBaseUnit", () => {
       }),
     ).toBe("-1999999");
   });
+
+  it("handles large numbers with zero decimals", () => {
+    expect(toBaseUnit("988288776786168845847765", { decimals: 0 })).toBe(
+      "988288776786168845847765",
+    );
+  });
 });
 
 describe("formatPercent", () => {

--- a/src/format.ts
+++ b/src/format.ts
@@ -175,7 +175,7 @@ export function toBaseUnit(
   if (!num) return fallback;
 
   const result = num.times(getPowerOf10(decimals));
-  return result.integerValue(roundingMode).toString();
+  return result.integerValue(roundingMode).toFixed();
 }
 
 interface FormatPercentOptions {


### PR DESCRIPTION
- Changed from toString() to toFixed() to properly handle large numbers
- Added test case for large numbers with zero decimals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of very large numeric strings in value conversion to ensure correct formatting when no decimals are specified.

* **Tests**
  * Added a new test case to verify correct processing of large integer strings with zero decimals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->