### PR TITLE
fix: update fromBaseUnit to remove trailing zeros

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ formatNumber("1.235", { dp: 2, roundingMode: BigNumber.ROUND_HALF_UP }); // "1.2
 ```typescript
 import { toBaseUnit, fromBaseUnit } from "@initia/utils";
 
-// Convert base units to display amount
-fromBaseUnit("1500000", { decimals: 6 }); // "1.500000"
+// Convert base units to display amount (removes trailing zeros)
+fromBaseUnit("1500000", { decimals: 6 }); // "1.5"
 fromBaseUnit("1", { decimals: 6 }); // "0.000001"
-fromBaseUnit("1234567890", { decimals: 6 }); // "1234.567890"
+fromBaseUnit("1234567890", { decimals: 6 }); // "1234.56789"
 
 // Convert display amount to base units
 toBaseUnit("1.5", { decimals: 6 }); // "1500000"
@@ -316,7 +316,7 @@ Converts a display amount to base units.
 
 **fromBaseUnit(value, options?)**
 
-Converts base units to a display amount.
+Converts base units to a display amount with trailing zeros removed.
 
 - `value`: `number | string | bigint | BigNumber` - The amount in base units
 - `options.decimals`: `number` - Token decimals (default: 0)

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -293,21 +293,21 @@ describe("formatAmount", () => {
 
 describe("fromBaseUnit", () => {
   it("converts from base unit", () => {
-    expect(fromBaseUnit("1234567890", { decimals: 6 })).toBe("1234.567890");
+    expect(fromBaseUnit("1234567890", { decimals: 6 })).toBe("1234.56789");
     expect(fromBaseUnit("1234567890", { decimals: 0 })).toBe("1234567890");
-    expect(fromBaseUnit("1000000", { decimals: 6 })).toBe("1.000000");
+    expect(fromBaseUnit("1000000", { decimals: 6 })).toBe("1");
   });
 
   it("handles negative values", () => {
-    expect(fromBaseUnit("-1234567890", { decimals: 6 })).toBe("-1234.567890");
-    expect(fromBaseUnit("-1000000", { decimals: 6 })).toBe("-1.000000");
+    expect(fromBaseUnit("-1234567890", { decimals: 6 })).toBe("-1234.56789");
+    expect(fromBaseUnit("-1000000", { decimals: 6 })).toBe("-1");
   });
 
   it("limits decimal places", () => {
     expect(fromBaseUnit("1234567890123456789", { decimals: 18 })).toBe(
       "1.234567",
     );
-    expect(fromBaseUnit("1", { decimals: 10 })).toBe("0.000000");
+    expect(fromBaseUnit("1", { decimals: 10 })).toBe("0");
   });
 
   it("handles invalid values", () => {
@@ -331,9 +331,9 @@ describe("fromBaseUnit", () => {
 
   it("handles bigint values", () => {
     expect(fromBaseUnit(BigInt("1234567890"), { decimals: 6 })).toBe(
-      "1234.567890",
+      "1234.56789",
     );
-    expect(fromBaseUnit(BigInt("-1000000"), { decimals: 6 })).toBe("-1.000000");
+    expect(fromBaseUnit(BigInt("-1000000"), { decimals: 6 })).toBe("-1");
     expect(fromBaseUnit(BigInt("1234567890123456789"), { decimals: 18 })).toBe(
       "1.234567",
     );
@@ -343,7 +343,7 @@ describe("fromBaseUnit", () => {
     // Default is ROUND_DOWN
     expect(fromBaseUnit("1234567896", { decimals: 6 })).toBe("1234.567896");
 
-    // ROUND_UP (note: toFixed with limited decimals)
+    // ROUND_UP (note: limited to max 6 decimals)
     expect(
       fromBaseUnit("1234567896123456789", {
         decimals: 18,

--- a/src/format.ts
+++ b/src/format.ts
@@ -147,7 +147,7 @@ interface FromBaseUnitOptions {
 
 /**
  * Converts a value from base units to display units.
- * Always returns a fixed decimal string without abbreviation.
+ * Returns a string without trailing zeros.
  * @param value - The value in base units
  * @param options - Options including decimals, fallback value, and roundingMode
  */
@@ -167,7 +167,9 @@ export function fromBaseUnit(
   const result = num.div(getPowerOf10(decimals));
   const decimalPlaces = Math.min(decimals, 6);
 
-  return result.toFixed(decimalPlaces, roundingMode);
+  // Remove trailing zeros as this function is for conversion, not formatting
+  // Formatting with preserved trailing zeros should use formatAmount() instead
+  return result.decimalPlaces(decimalPlaces, roundingMode).toFixed();
 }
 
 interface ToBaseUnitOptions {
@@ -178,7 +180,7 @@ interface ToBaseUnitOptions {
 
 /**
  * Converts a value from display units to base units.
- * Returns an integer string representation.
+ * Always returns an integer string representation as blockchain doesn't support fractional amounts.
  * @param value - The value in display units
  * @param options - Options including decimals, fallback value, and roundingMode
  */
@@ -196,6 +198,7 @@ export function toBaseUnit(
   if (!num) return fallback;
 
   const result = num.times(getPowerOf10(decimals));
+  // Always return an integer as blockchain doesn't support fractional amounts
   return result.integerValue(roundingMode).toFixed();
 }
 


### PR DESCRIPTION
- Remove trailing zeros from fromBaseUnit() output as it's for conversion, not formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * fromBaseUnit now trims trailing zeros and omits the decimal point when there’s no fractional part.
  * toBaseUnit now consistently returns an integer-only string to match blockchain constraints.

* **Documentation**
  * Updated README and API reference to reflect trimmed outputs; revised examples for clarity.

* **Tests**
  * Adjusted unit tests to expect trimmed results for positive, negative, and BigInt inputs.
  * Clarified rounding behavior in comments (rounding up limited to 6 decimals).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->